### PR TITLE
Adds saltus_models filter

### DIFF
--- a/src/Modeler.php
+++ b/src/Modeler.php
@@ -65,6 +65,15 @@ class Modeler {
 				);
 			}
 		}
+
+		// check for models added with filters
+		if ( has_filter( 'saltus_models' ) ) {
+			$model  = apply_filters( 'saltus_models', [] );
+			( ! empty( $model ) && count( $model ) > 0 ?
+					$this->iterate_multiple($model ) :
+					$this->create( $model )
+				);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added the saltus_models filter to the Moduler file. 
This way we can add models using filters, in addition to the PHP files. 
Useful when creating addon plugins for example that extend the already existing Saltus based plugin with other CPTs or taxonomies.