### PR TITLE
add filter to fix line breaks on cpt save to fix export/import issue

### DIFF
--- a/src/Features/Meta/CodestarMeta.php
+++ b/src/Features/Meta/CodestarMeta.php
@@ -77,6 +77,9 @@ final class CodestarMeta {
 			}
 		}
 
+		// add filter to properly save line breaks in this meta box
+		add_filter( sprintf( 'csf_%s_save', $box_id ), array( $this, 'sanitize_meta_save' ), 1, 3 );
+
 	}
 
 	/**
@@ -120,6 +123,32 @@ final class CodestarMeta {
 
 		// codestar framework 'prefers' keys to be a numeric index, so we return the array_values
 		return array_values( $fields );
+	}
+
+	/**
+	 * Function to sanitize meta on save
+	 *
+	 * @param array $request with meta info
+	 * @param int $post_id
+	 * @param obj $csf class
+	 * @return array
+	 */
+	public function sanitize_meta_save( $request, $post_id, $csf ) {
+
+		if ( empty( $request ) || ! is_array( $request ) ) {
+			return $request;
+		}
+
+		//replace line breaks on meta info to make it compatible with export
+		array_walk_recursive(
+			$request,
+			function ( &$value ) {
+				$value = str_replace( "\r\n", "\n", $value );
+			}
+		);
+
+		return $request;
+
 	}
 
 


### PR DESCRIPTION
To replicate the issue, create a cpt entry with line breaks in a text area, then export the entry.
On import, the meta will not import. This is because the line breaks character is not serielized correctly in the XML. 
Similar to this issue: https://core.trac.wordpress.org/ticket/34845
This fix adds a filter to replace the line breaks characters to the correct ones.
@LC43 if the CodestarMeta.php file is not the best place to include the fix, let me know where we should place it.